### PR TITLE
InternationalFormat2Lines - Use address1 as first line if empty

### DIFF
--- a/lib/smartystreets_api/decorators/base_decorator.rb
+++ b/lib/smartystreets_api/decorators/base_decorator.rb
@@ -2,7 +2,7 @@ class SmartyStreetsApi::Decorators::BaseDecorator
   def call(address_object)
     return if !address_object || !address_object[:components]
 
-    self.class.private_instance_methods(false).inject({}) do |decorated_address, attribute|
+    decorated_components = self.class.private_instance_methods(false).inject({}) do |decorated_address, attribute|
       components = self.send(attribute.to_sym)
 
       array_values = components.map do |component_name|
@@ -17,5 +17,9 @@ class SmartyStreetsApi::Decorators::BaseDecorator
 
       decorated_address
     end
+
+    remove_empty_address_lines!(decorated_components)
+
+    decorated_components
   end
 end

--- a/lib/smartystreets_api/decorators/international_format.rb
+++ b/lib/smartystreets_api/decorators/international_format.rb
@@ -4,6 +4,10 @@ class SmartyStreetsApi::Decorators::InternationalFormat < SmartyStreetsApi::Deco
 
     decorated_address[:organization] = address_object[:lines][:organization]
 
+    decorated_address
+  end
+
+  def remove_empty_address_lines!(decorated_address)
     unless decorated_address[:address2]
       decorated_address[:address2] = decorated_address[:address3]
       decorated_address[:address3] = nil
@@ -14,8 +18,6 @@ class SmartyStreetsApi::Decorators::InternationalFormat < SmartyStreetsApi::Deco
       decorated_address[:address2] = decorated_address[:address3]
       decorated_address[:address3] = nil
     end
-
-    decorated_address
   end
 
   private

--- a/lib/smartystreets_api/decorators/international_format_2_lines.rb
+++ b/lib/smartystreets_api/decorators/international_format_2_lines.rb
@@ -4,6 +4,10 @@ class SmartyStreetsApi::Decorators::InternationalFormat2Lines < SmartyStreetsApi
 
     decorated_address[:organization] = address_object[:lines][:organization]
 
+    decorated_address
+  end
+
+  def remove_empty_address_lines!(decorated_address)
     unless decorated_address[:address1]
       decorated_address[:address1] = decorated_address[:address_1_alternative]
       decorated_address[:address2] = decorated_address[:address_2_alternative]
@@ -12,7 +16,10 @@ class SmartyStreetsApi::Decorators::InternationalFormat2Lines < SmartyStreetsApi
     decorated_address.delete(:address_1_alternative)
     decorated_address.delete(:address_2_alternative)
 
-    decorated_address
+    unless decorated_address[:address1]
+      decorated_address[:address1] = decorated_address[:address2]
+      decorated_address[:address2] = nil
+    end
   end
 
   private

--- a/lib/smartystreets_api/decorators/us_format.rb
+++ b/lib/smartystreets_api/decorators/us_format.rb
@@ -1,4 +1,11 @@
 class SmartyStreetsApi::Decorators::UsFormat < SmartyStreetsApi::Decorators::BaseDecorator
+  def remove_empty_address_lines!(decorated_address)
+    unless decorated_address[:street]
+      decorated_address[:street] = decorated_address[:secondary]
+      decorated_address[:secondary] = nil
+    end
+  end
+
   private
 
   def street

--- a/spec/cassettes/international/valid_ca_po_box.yml
+++ b/spec/cassettes/international/valid_ca_po_box.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://international-street.api.smartystreets.com/verify?address1=PO%20BOX%201&address2&administrative_area=SK&auth-id=AUTH-ID&auth-token=AUTH-TOKEN&country=CAN&locality=Pilger&organization&postal_code=S0K%203G0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - international-street.api.smartystreets.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '467'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Sep 2018 19:19:17 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"address1":"PO Box 1","address2":"Pilger SK S0K 3G0","components":{"administrative_area":"SK","country_iso_3":"CAN","locality":"Pilger","postal_code":"S0K
+        3G0","postal_code_short":"S0K 3G0","post_box":"PO Box 1","post_box_number":"1","post_box_type":"PO
+        Box"},"metadata":{"address_format":"post_box|locality administrative_area
+        postal_code"},"analysis":{"verification_status":"Verified","address_precision":"DeliveryPoint","max_address_precision":"DeliveryPoint"}}]'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 19:19:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/decorators/international_format_2_lines_spec.rb
+++ b/spec/lib/decorators/international_format_2_lines_spec.rb
@@ -43,6 +43,29 @@ describe SmartyStreetsApi::Decorators::InternationalFormat2Lines do
       postal_code_short: "HP19 3EQ"
     }
   end
+  let(:ca_address_po_box) do
+    {
+      country: "CAN",
+      organization: nil,
+      address1: "PO BOX 1",
+      address2: nil,
+      administrative_area: "SK",
+      locality: "Pilger",
+      postal_code: "S0K 3G0"
+    }
+  end
+  let(:ca_decorated_address_po_box) do
+    {
+      country: "CAN",
+      organization: nil,
+      address1: "PO Box 1",
+      address2: nil,
+      administrative_area: "SK",
+      locality: "Pilger",
+      postal_code: "S0K 3G0",
+      postal_code_short: "S0K 3G0"
+    }
+  end
 
   it "should decorate correctly a simple address" do
     VCR.use_cassette("international/valid_rus") do
@@ -57,6 +80,14 @@ describe SmartyStreetsApi::Decorators::InternationalFormat2Lines do
       response = SmartyStreetsApi::InternationalStreetAddress.get_single(uk_address_with_building)
 
       expect(described_class.new.call(response.first)).to eq(uk_decorated_address_with_building)
+    end
+  end
+
+  it 'should replace address1 with address2 if empty' do
+    VCR.use_cassette("international/valid_ca_po_box") do
+      response = SmartyStreetsApi::InternationalStreetAddress.get_single(ca_address_po_box)
+
+      expect(described_class.new.call(response.first)).to eq(ca_decorated_address_po_box)
     end
   end
 end


### PR DESCRIPTION
## Context 
There are cases where the 2 line formatter does not have data on the first line. When that happens the second should take precedence and be on the first line.

Example:
```
Po Box 1
S0K 3G0 Pilger
Canada
```